### PR TITLE
Add client shipments method

### DIFF
--- a/lib/shipstation/client.rb
+++ b/lib/shipstation/client.rb
@@ -106,6 +106,15 @@ module ShipStation
       self.class.get("/shipments", options)
     end
 
+    def shipments(params = {})
+      options = {}
+
+      authit(options)
+      options[:query] = params
+
+      self.class.get("/shipments", options)
+    end
+
     def list_stores(marketplace = 0)
       options = {}
       authit(options)

--- a/spec/shipstation/client_spec.rb
+++ b/spec/shipstation/client_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe ShipStation::Client do
+  AUTH_KEY = 'some-key'
+  AUTH_SECRET = 'some-secret'
+
+  let(:client) { described_class.new(AUTH_KEY, AUTH_SECRET) }
+  subject { client }
+
+  describe '#shipments' do
+    subject { super().shipments }
+
+    it 'hits the correct API endpoint' do
+      expect(described_class).to receive(:get).with('/shipments', anything)
+      subject
+    end
+
+    it 'attaches the auth' do
+      expect(described_class).to receive(:get)
+        .with(anything, hash_including({ basic_auth: { password: AUTH_SECRET, username: AUTH_KEY }, verify: false }))
+      subject
+    end
+
+    it 'sends any options passed' do
+      options = { a: 1, b: 2 }
+      expect(described_class).to receive(:get).with(anything, hash_including({ query: options }))
+      client.shipments(options)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a `client.shipments(options)` method. Regrettably, there is no way to fully test this because we don't have any shipments in our account, but tests have been added to verify the mocked functionality.