### PR TITLE
Add ShipStation::Client#fulfillments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shipstation (0.1.0)
+    shipstation (0.3.0)
       hashie
       httparty
 
@@ -10,12 +10,12 @@ GEM
   specs:
     diff-lcs (1.3)
     hashie (4.1.0)
-    httparty (0.18.0)
+    httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2021.0225)
     multi_xml (0.6.0)
     rake (12.3.3)
     rspec (3.9.0)

--- a/lib/shipstation/client.rb
+++ b/lib/shipstation/client.rb
@@ -128,6 +128,15 @@ module ShipStation
       self.class.get("/shipments", options)
     end
 
+    def fulfillments(params = {})
+      options = {}
+
+      authit(options)
+      options[:query] = params
+
+      self.class.get("/fulfillments", options)
+    end
+
     def list_stores(marketplace = 0)
       options = {}
       authit(options)

--- a/lib/shipstation/version.rb
+++ b/lib/shipstation/version.rb
@@ -1,3 +1,3 @@
 module ShipStation
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/shipstation/client_spec.rb
+++ b/spec/shipstation/client_spec.rb
@@ -28,6 +28,27 @@ RSpec.describe ShipStation::Client do
     end
   end
 
+  describe '#fulfillments' do
+    subject{ super().fulfillments }
+
+    it 'hits the correct API endpoint' do
+      expect(described_class).to receive(:get).with('/fulfillments', anything)
+      subject
+    end
+
+    it 'attaches the auth' do
+      expect(described_class).to receive(:get)
+        .with(anything, hash_including({ basic_auth: { password: AUTH_SECRET, username: AUTH_KEY }, verify: false }))
+      subject
+    end
+
+    it 'sends any options passed' do
+      options = { a: 1, b: 2 }
+      expect(described_class).to receive(:get).with(anything, hash_including({ query: options }))
+      client.fulfillments(options)
+    end
+  end
+
   describe '#order' do
     context 'with too many orders' do
       let(:order_id) {4}


### PR DESCRIPTION
## Context

Since fulfillments are not handled by the `/shipments` endpoint, this adds a `ShipStation::Client#fulfillments` method that points at `/fulfillments`

## Changes

- [ ] Add `ShipStation::Client#fulfillments` with associated spec
- [ ] Bump version to `0.3.0`